### PR TITLE
require Julia 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
+julia 0.6
 DataStructures 0.5.1


### PR DESCRIPTION
I forgot to update REQUIRE when dropping Julia 0.5, which confuses JuliaCIBot (https://github.com/JuliaLang/METADATA.jl/pull/12310). I'm going to tag a new version soon after merging this.