### PR TITLE
Fix escaping - and ^ inside character classes.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ include("test13.jl")
 include("test14.jl")
 include("test15.jl")
 include("test16.jl")
+include("test17.jl")
 
 module TestFASTA
 

--- a/test/test17.jl
+++ b/test/test17.jl
@@ -1,0 +1,58 @@
+module Test17
+
+if VERSION >= v"0.7-"
+    using Test
+else
+    using Base.Test
+end
+import Automa
+import Automa.RegExp: @re_str
+import Compat: lastindex, occursin
+
+@testset "Test17" begin
+    re1 = re"[a\-c]"
+    re1.actions[:enter] = [:enter]
+    re1.actions[:exit] = [:exit]
+    machine1 = Automa.compile(re1)
+    @test occursin(r"^Automa.Machine\(<.*>\)$", repr(machine1))
+
+    for generator in (:table, :inline, :goto), checkbounds in (true, false), clean in (true, false)
+        ctx = Automa.CodeGenContext(generator=generator, checkbounds=checkbounds, clean=clean)
+        init_code = Automa.generate_init_code(ctx, machine1)
+        exec_code = Automa.generate_exec_code(ctx, machine1, :debug)
+        validate = @eval function (data)
+            logger = Symbol[]
+            $(init_code)
+            p_end = p_eof = lastindex(data)
+            $(exec_code)
+            return cs == 0, logger
+        end
+
+        @test validate(b"-") == (true, [:enter, :exit])
+        @test validate(b"b") == (false, Symbol[])
+    end
+
+    re2 = re"[a-c]"
+    re2.actions[:enter] = [:enter]
+    re2.actions[:exit] = [:exit]
+    machine2 = Automa.compile(re2)
+    @test occursin(r"^Automa.Machine\(<.*>\)$", repr(machine2))
+
+    for generator in (:table, :inline, :goto), checkbounds in (true, false), clean in (true, false)
+        ctx = Automa.CodeGenContext(generator=generator, checkbounds=checkbounds, clean=clean)
+        init_code = Automa.generate_init_code(ctx, machine2)
+        exec_code = Automa.generate_exec_code(ctx, machine2, :debug)
+        validate = @eval function (data)
+            logger = Symbol[]
+            $(init_code)
+            p_end = p_eof = lastindex(data)
+            $(exec_code)
+            return cs == 0, logger
+        end
+
+        @test validate(b"-") == (false, [])
+        @test validate(b"b") == (true, Symbol[:enter, :exit])
+    end
+end
+
+end


### PR DESCRIPTION
Currently `re"[a-z]"` is equivalent to `re"[a\-z]"`, and similarly `re"[^a]"` is equivalent `re"[\^a]"`. This patch allows escaping these characters in character class specification like this, which I think was the intended behavior.

I noticed this issue in our GFF3 parser, which has an escaped `\-` that is not recognized. As a result entries with sequence names containing dashes aren't parsed. (PR with test case here: https://github.com/BioJulia/BioFmtSpecimens/pull/27).

cc: @bicycle1885