### PR TITLE
Disallow DFAs with ambiguous actions [RFC]

### DIFF
--- a/src/dfa.jl
+++ b/src/dfa.jl
@@ -143,6 +143,7 @@ end
 function get_epsilon_paths(tops::Set{NFANode})
     paths = Tuple{Union{Nothing, Edge}, Vector{Symbol}}[]
     heads = [(node, Symbol[]) for node in tops]
+    visited = Set{NFANode}()
     while !isempty(heads)
         node, actions = pop!(heads)
         if iszero(length(node.edges))
@@ -150,11 +151,14 @@ function get_epsilon_paths(tops::Set{NFANode})
         end
         for (edge, child) in node.edges
             if iseps(edge)
-                push!(heads, (child, append!(copy(actions), [a.name for a in edge.actions])))
+                if !in(node, visited)
+                    push!(heads, (child, append!(copy(actions), [a.name for a in edge.actions])))
+                end
             else
                 push!(paths, (edge, actions))
             end
         end
+        push!(visited, node)
     end
     return paths
 end

--- a/src/machine.jl
+++ b/src/machine.jl
@@ -35,8 +35,24 @@ function Base.show(io::IO, machine::Machine)
     print(io, summary(machine), "(<states=", machine.states, ",start_state=", machine.start_state, ",final_states=", machine.final_states, ">)")
 end
 
-function compile(re::RegExp.RE; optimize::Bool=true)
-    dfa = nfa2dfa(remove_dead_nodes(re2nfa(re)))
+"""
+    compile(re::RegExp; optimize, unambiguous) -> Machine
+
+Compile a finite state machine (FSM) from RegExp `re`. If `optimize`, attempt to minimize the number
+of states in the FSM. If `unambiguous`, disallow creation of FSM where the actions are not deterministic.
+
+# Examples
+```
+machine let
+    name = re"[A-Z][a-z]+"
+    first_last = name * re" " * name
+    last_first = name * re", " * name
+    Automa.compile(first_last | last_first)
+end
+```
+"""
+function compile(re::RegExp.RE; optimize::Bool=true, unambiguous::Bool=true)
+    dfa = nfa2dfa(remove_dead_nodes(re2nfa(re)), unambiguous)
     if optimize
         dfa = remove_dead_nodes(reduce_nodes(dfa))
     end

--- a/src/nfa.jl
+++ b/src/nfa.jl
@@ -113,7 +113,7 @@ function re2nfa(re::RegExp.RE, predefined_actions::Dict{Symbol,Action}=Dict{Symb
             else  # re.head == :diff
                 revoke = s -> f2 ∈ s.nfanodes
             end
-            nfa = dfa2nfa(revoke_finals(revoke, nfa2dfa(NFA(start_in, final_in))))
+            nfa = dfa2nfa(revoke_finals(revoke, nfa2dfa(NFA(start_in, final_in), false)))
             push!(start_in.edges, (Edge(eps), nfa.start))
             final_in = nfa.final
         else

--- a/src/precond.jl
+++ b/src/precond.jl
@@ -36,7 +36,7 @@ end
 
 function Base.getindex(precond::Precondition, name::Symbol)
     i = findfirst(n -> n == name, precond.names)
-    if i == 0
+    if i === nothing
         return BOTH
     else
         return precond.values[i]
@@ -46,7 +46,7 @@ end
 function Base.push!(precond::Precondition, kv::Pair{Symbol,Value})
     name, value = kv
     i = findfirst(n -> n == name, precond.names)
-    if i == nothing
+    if i === nothing
         push!(precond.names, name)
         push!(precond.values, value)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,7 @@ include("test15.jl")
 include("test16.jl")
 include("test17.jl")
 include("test18.jl")
+include("test19.jl")
 
 module TestFASTA
 using Test

--- a/test/test11.jl
+++ b/test/test11.jl
@@ -6,11 +6,11 @@ const re = Automa.RegExp
 using Test
 
 @testset "Test11" begin
-    a = re"[a-z]"
+    a = re"[a-z]+"
     a.when = :le
     a = re.rep1(a)
     a.actions[:exit] = [:one]
-    b = re"[a-z][a-z0-9]*"
+    b = re"[a-z]+[0-9]+"
     b.actions[:exit] = [:two]
 
     machine = Automa.compile(re.cat(a | b, '\n'))
@@ -31,12 +31,12 @@ using Test
             $(Automa.generate_exec_code(ctx, machine, actions))
             return logger, cs == 0 ? :ok : cs < 0 ? :error : :incomplete
         end
-        @test validate(b"a\n", 0) == ([:two], :ok)
-        @test validate(b"a\n", 1) == ([:one, :two], :ok)
+        @test validate(b"a\n", 0) == ([], :error)
+        @test validate(b"a\n", 1) == ([:one], :ok)
         @test validate(b"a1\n", 1) == ([:two], :ok)
-        @test validate(b"aa\n", 1) == ([:two], :ok)
+        @test validate(b"aa\n", 1) == ([], :error)
         @test validate(b"aa1\n", 1) == ([:two], :ok)
-        @test validate(b"aa\n", 2) == ([:one, :two], :ok)
+        @test validate(b"aa\n", 2) == ([:one], :ok)
         @test validate(b"aa1\n", 2) == ([:two], :ok)
         @test validate(b"1\n", 1) == ([], :error)
     end

--- a/test/test19.jl
+++ b/test/test19.jl
@@ -6,11 +6,12 @@ const re = Automa.RegExp
 using Test
 
 @testset "Test19" begin
-    # Ambiguous exit statement
+    # Ambiguous enter statement
     A = re"XY"
     B = re"XZ"
     A.actions[:enter] = [:enter_A]
     @test_throws ErrorException Automa.compile(A | B)
+    @test Automa.compile(A | B, unambiguous=false) isa Automa.Machine
 
     # Ambiguous, but no action in ambiguity
     A = re"XY"
@@ -23,10 +24,22 @@ using Test
 
     A.actions[:enter] = [:enter_A]
     @test_throws ErrorException Automa.compile(A | B)
+    @test Automa.compile(A | B, unambiguous=false) isa Automa.Machine
 
     A = re"aa"
     A.actions[:exit] = [:exit_A]
     @test_throws ErrorException Automa.compile(A | B)
+    @test Automa.compile(A | B, unambiguous=false) isa Automa.Machine
+
+    # Harder test case
+    A = re"AAAAB"
+    B = re"A+C"
+    A.actions[:exit] = [:exit_A]
+    B.actions[:exit] = [:exit_B]
+    @test Automa.compile(A | B) isa Automa.Machine
+
+    # TODO: Also need test for whether ambiguous edges can be
+    # resolved by conflicting preconditions and allow compilation.
 end
 
 end

--- a/test/test19.jl
+++ b/test/test19.jl
@@ -1,0 +1,32 @@
+module Test19
+
+import Automa
+import Automa.RegExp: @re_str
+const re = Automa.RegExp
+using Test
+
+@testset "Test19" begin
+    # Ambiguous exit statement
+    A = re"XY"
+    B = re"XZ"
+    A.actions[:enter] = [:enter_A]
+    @test_throws ErrorException Automa.compile(A | B)
+
+    # Ambiguous, but no action in ambiguity
+    A = re"XY"
+    A.actions[:exit] = [:exit_A]
+    @test Automa.compile(A | B) isa Automa.Machine
+
+    A = re"aa"
+    B = re"a+"
+    @test Automa.compile(A | B) isa Automa.Machine
+
+    A.actions[:enter] = [:enter_A]
+    @test_throws ErrorException Automa.compile(A | B)
+
+    A = re"aa"
+    A.actions[:exit] = [:exit_A]
+    @test_throws ErrorException Automa.compile(A | B)
+end
+
+end


### PR DESCRIPTION
See issue #48 . With this PR, attempting to create a DFA with ambiguous actions will result in an error.

Before:
```
machine = let
   A = re"XY"
   B = re"XZ"
   A.actions[:enter] = [:entering_A]
   Automa.compile(A | B)
end
```
Here, the machine, when seeing an `X`, won't know if it has to execute `:entering_A` or not. Previously, all possible actions were taken, even mututally exclusive ones, which could result in unexpected and self-contradicting behaviour, like exiting the same regex multiple times, or entering a regex and never exiting it (even at EOF).
With this commit, the above code raises an error:
`ERROR: Ambiguous NFA: Byte 0x58 can lead to actions nothing or [:entering_A]`

Note that you can still have ambiguous DFAs if the *actions* are not ambiguous, for example this code will still work:
```
machine = let
   A = re"XY"
   B = re"XZ"
   A.actions[:exit] = [:exiting_A]
   Automa.compile(A | B)
end
```
While the machine don't know if it is entering A or B, that doesn't matter because they lead to the same actions. And when exiting A, the machine knows for certain that it's not exiting B.

Edit: This change will cause multiple tests to fail, because several tests include ambiguous DFAs. I think the tests should be changed, but want comments for this.