### PR TITLE
Allow no actions in generate exec code

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -106,7 +106,7 @@ Generate machine execution code with actions.
 function generate_exec_code(ctx::CodeGenContext, machine::Machine, actions=nothing)
     # make actions
     if actions == nothing
-        actions = Dict{Symbol,Expr}()
+        actions = Dict{Symbol,Expr}(a => quote nothing end for a in action_names(machine))
     elseif actions == :debug
         actions = debug_actions(machine)
     elseif isa(actions, AbstractDict{Symbol,Expr})
@@ -477,7 +477,7 @@ function cleanup(ex::Expr)
     return Expr(ex.head, args...)
 end
 
-function debug_actions(machine::Machine)
+function action_names(machine::Machine)
     actions = Set{Symbol}()
     for s in traverse(machine.start)
         for (e, t) in s.edges
@@ -487,6 +487,11 @@ function debug_actions(machine::Machine)
     for as in values(machine.eof_actions)
         union!(actions, a.name for a in as)
     end
+    return actions
+end
+
+function debug_actions(machine::Machine)
+    actions = action_names(machine)
     function log_expr(name)
         return :(push!(logger, $(QuoteNode(name))))
     end


### PR DESCRIPTION
Allows you do nearly effortlessly generate code from a `Machine` while disregarding its actions by passing `nothing` as the actions. This is useful to create validating parsers, e.g. here is a validating FASTA parser which uses the existing `FASTX.FASTA.machine` and its context.

```
import Automa
import FASTX

@eval function validate_fasta(data::Vector{UInt8})
    $(Automa.generate_init_code(FASTA.context, FASTA.machine))
    p_end = p_eof = lastindex(data)
    $(Automa.generate_exec_code(FASTA.context, FASTA.machine, nothing))
    return iszero(cs)
end
```

It's much easier to do than building a new machine, the code is smaller, and the machine is faster (the above validator validates a 150 MB FASTA file in 57 ms on my laptop). Remarkably, `Automa` already had an option to pass `nothing` as the actions, but it didn't actually work.