### PR TITLE
Improve DFA edge reduction

### DIFF
--- a/src/dfa.jl
+++ b/src/dfa.jl
@@ -26,7 +26,6 @@ end
 
 # Check if the DFA is really deterministic or not.
 function validate(dfa::DFA)
-    is_non_deterministic(e1, e2) = !(isdisjoint(e1.labels, e2.labels) || conflicts(e1.precond, e2.precond))
     for s in traverse(dfa.start)
         for i in 1:lastindex(s.edges), j in 1:i-1
             ei = s.edges[i][1]
@@ -255,7 +254,20 @@ function reduce_nodes(dfa::DFA)
             if !isvisited(T)
                 push!(unvisited, T)
             end
-            push!(s′.edges, (e, new(T)))
+
+            # Here, add the old edge to the new DFA. If an equivalent edge already
+            # exists, instead add the labels of the old edge to the existing one.
+            existing_edge = false
+            for (i, (e´, t´)) in enumerate(s′.edges)
+                if t´ == new(T) && e´.precond == e.precond && e´.actions == e.actions
+                    newlabels = union(e.labels, e´.labels)
+                    newedge = Edge(newlabels, e.precond, e.actions)
+                    s′.edges[i] = (newedge, t´)
+                    existing_edge = true
+                    break
+                end
+            end
+            existing_edge || push!(s′.edges, (e, new(T)))
         end
     end
     return DFA(start)

--- a/src/precond.jl
+++ b/src/precond.jl
@@ -34,9 +34,13 @@ function Precondition()
     return Precondition(Symbol[], Value[])
 end
 
+function Base.:(==)(p1::Precondition, p2::Precondition)
+    return p1.names == p2.names && p1.values == p2.values
+end
+
 function Base.getindex(precond::Precondition, name::Symbol)
     i = findfirst(n -> n == name, precond.names)
-    if i == 0
+    if i === nothing
         return BOTH
     else
         return precond.values[i]
@@ -46,7 +50,7 @@ end
 function Base.push!(precond::Precondition, kv::Pair{Symbol,Value})
     name, value = kv
     i = findfirst(n -> n == name, precond.names)
-    if i == nothing
+    if i === nothing
         push!(precond.names, name)
         push!(precond.values, value)
     else


### PR DESCRIPTION
This is best illustrated with an example:
First, create this DFA:
```
import Automa
const re = Automa.RegExp
dfa = Automa.nfa2dfa(Automa.re2nfa(re.rep(re.rep(re.any()) * re.opt(re.parse("A")))))
```
Then visualise it:
![image](https://user-images.githubusercontent.com/23193950/97696826-69fcca80-1aa6-11eb-92c1-bc573d39b2be.png)

Note that these three nodes are indistinguishable. Indeed, once we optimize the DFA:
```
dfa = reduce_nodes(dfa)
```
We get one with only one node:
![image](https://user-images.githubusercontent.com/23193950/97797652-f92cee00-1c1e-11eb-9938-c01c6b9903ad.png)
But look at the edges! Clearly, the *edges* are now indistinguishable! Why are they not collapsed to a single edge?
Briefly, what it did before was:
* After realizing nodes 1, 2 and 3 can be represented by the single node {1, 2, 3}, it needs to add edges. Since the nodes are indistinguishable, they must have equivalent edges, so that means the new edges are simply the edges of any node in {1, 2, 3}.
* So it took a random node, e.g. 1, and duplicated its edges - this time to itself since nodes 2 and 3 are the same as 1.
* However, it didn't take into account that some nodes even could be collapsed, because they point to the same child. For example, the edge from 1 to 2 is the "same" edge as that from 1 to 3, because it has the same actions, preconditions, source and destination.

Now, it checks if an equivalent edge already exists before adding a second one. If an equivalent edge does exist, it simply unions the edge labels
