### PR TITLE
Improve debugging of Automa

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -579,6 +579,17 @@ function generate_membership_code(var::Symbol, set::ByteSet)
     end
 end
 
+function generate_input_error_code(ctx::CodeGenContext, machine::Machine)
+    byte_symbol = gensym()
+    vars = ctx.vars
+    return quote
+        if $(vars.cs) < 0
+            $byte_symbol = ($(vars.p_eof > -1) && $(vars.p) > $(vars.p_eof)) ? nothing : $(vars.byte)
+            Automa.throw_input_error($(machine), -$(vars.cs), $byte_symbol, $(vars.mem), $(vars.p))
+        end
+    end
+end
+
 # Used by the :table and :inline code generators.
 function rewrite_special_macros(ctx::CodeGenContext, ex::Expr, eof::Bool)
     args = []

--- a/src/dfa.jl
+++ b/src/dfa.jl
@@ -175,11 +175,12 @@ function validate_paths(paths::Vector{Tuple{Union{Nothing, Edge}, NFANode, Vecto
             actions1 == actions2 && continue
             eof = (edge1 === nothing) & (edge2 === nothing)
             !(eof || overlaps(edge1, edge2)) && continue
-            byte = eof ? "EOF" : repr(first(intersect(edge1.labels, edge2.labels)))
+            byte = eof ? "EOF" : first(intersect(edge1.labels, edge2.labels))
+            char = repr(reinterpret(Char, (byte % UInt32) << 24))
             a1 = isempty(actions1) ? "nothing" : actions1
             a2 = isempty(actions2) ? "nothing" : actions2
             o1, o2 = order[node1], order[node2]
-            error("Ambiguous DFA: Input $byte from NFA node(s) $o1 & $o2 can lead to actions $a1 or $a2")
+            error("Ambiguous DFA: Input $char from NFA node(s) $o1 & $o2 can lead to actions $a1 or $a2")
         end
     end
 end

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -1,0 +1,57 @@
+function debug_machine(machine::Automa.Machine)
+    @assert machine.start_state == 1
+    cloned_nodes = [Automa.Node(i) for i in machine.states]
+    for node in Automa.traverse(machine.start)
+        for (edge, child) in node.edges
+            cloned_edge = Automa.Edge(
+                edge.labels,
+                edge.precond,
+                Automa.ActionList(copy(edge.actions.actions))
+            )
+            isempty(cloned_edge.actions) || @assert -1 < minimum(edge.actions.actions) do action
+                action.order
+            end
+            push!(cloned_edge.actions, Automa.Action(:debug, -1))
+            push!(cloned_nodes[node.state].edges, (cloned_edge, cloned_nodes[child.state]))
+        end
+    end
+    Automa.Machine(
+        cloned_nodes[1],
+        1:length(cloned_nodes),
+        1,
+        copy(machine.final_states),
+        copy(machine.eof_actions)   
+    )
+end
+
+function create_debug_code(machine::Automa.Machine; ascii::Bool=false,
+    ctx::Union{Automa.CodeGenContext, Nothing}=nothing
+)
+    ctx = ctx === nothing ? Automa.CodeGenContext() : ctx
+    logsym = gensym()
+    action_dict = Dict(map(collect(Automa.action_names(machine))) do name
+        name => quote
+            push!(last($logsym)[3], $(QuoteNode(name)))
+        end
+    end)
+    @assert !haskey(action_dict, :debug) "Machine can't contain action :debug"
+    action_dict[:debug] = quote
+        push!($logsym, ($(ctx.vars.byte), $(ctx.vars.cs), Symbol[])
+        )
+    end
+    debugger = debug_machine(machine)
+    quote
+        function execute_debug($(ctx.vars.data)::Union{String, Vector{UInt8}})
+            $logsym = $(if ascii
+                quote Tuple{Char, Int, Vector{Symbol}}[] end
+            else
+                quote Tuple{UInt8, Int, Vector{Symbol}}[] end
+            end)
+            $(Automa.generate_init_code(ctx, debugger))
+            p_end = p_eof = sizeof($(ctx.vars.data))
+            $(Automa.generate_exec_code(ctx, debugger, action_dict))
+            ($(ctx.vars.cs), $logsym)
+        end
+    end
+end
+


### PR DESCRIPTION
This PR adds some better debugging capacities to Automa.

I'll keep adding to this PR until we feel it's getting really useful.

## Currently implemented
* Error message for ambiguous DFAs now tell you which two NFA edges conflict, e.g:
```
ERROR: Ambiguous DFA: Input 0x58 from NFA node(s) 2 & 7 can lead to actions nothing or [:entering_A]
```
By using `Automa.nfa2dot`, one can visualize the NFA, locate the two nodes (node 2 and 7 in this case) and pin down exactly where the conflict happens
* `execute_debug` function. You use it like this:
```
include("test/debug.jl") # not included in Automa by default to cut down on load times
eval(create_debug_function(my_machine, ascii=true)) # defined the "execute_debug" function
execute_debug("some_text")
```
It returns a tuple, with the first element being the stopping state, and the second element being a vector of (input_byte, machine_state, actions) tuples. If `ascii` is true, the input bytes are `Char`s instead of `UInt8` to make it easier to read.
Demonstration:
```
julia> machine = let
          A = re"XY"
          B = re"XZ"
          A.actions[:exit] = [:entering_A]
          Automa.compile(A | B)
       end;

julia> eval(create_debug_function(machine; ascii=true))
execute_debug (generic function with 1 method)

julia> execute_debug("XY")
(0, [('X', 2, Symbol[]), ('Y', 3, [:entering_A])])
```
### Debug_execute
Added function to test regexes easier:
```
julia> (cs, events) = debug_execute(my_regex, ">foo", ascii=true);

julia> events
5-element Vector{Tuple{Union{Nothing, Char}, Int64, Vector{Symbol}}}:
 ('>', 2, [:foo!])
 ('f', 3, [])
 ('o', 4, [])
 ('o', 4, [])
 (nothing, 0, [])
```

 @kescobo Please come with suggestions of what other things to add which will make working with Automa more pleasant. :)