### PR TITLE
Fix execute (issue 78)

### DIFF
--- a/src/machine.jl
+++ b/src/machine.jl
@@ -94,6 +94,7 @@ function execute(machine::Machine, data::Vector{UInt8})
                 rethrow()
             end
             cs = -cs
+            break
         end
     end
     if cs ∈ machine.final_states && haskey(machine.eof_actions, s.state)

--- a/test/test10.jl
+++ b/test/test10.jl
@@ -48,6 +48,10 @@ using Test
     machine = Automa.compile(!re"foo")
     @test Automa.execute(machine, "bar")[1] == 0
     @test Automa.execute(machine, "foo")[1] < 0
+
+    machine = Automa.compile(re.rep("a"))
+    @test Automa.execute(machine, "aaa")[1] == 0
+    @test Automa.execute(machine, "aYa")[1] < 0
 end
 
 end


### PR DESCRIPTION
A simple missing `break` statement made the execution continue through invalid bytes and caused #78. Now fixed, and tests added.