### PR TITLE
Add workflow for downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,58 @@
+name: Downstream
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: BioJulia, repo: BED.jl, group: Automa}
+          - {user: BioJulia, repo: BigBed.jl, group: Automa}
+          - {user: BioJulia, repo: FASTX.jl, group: Automa}
+          - {user: BioJulia, repo: GeneticVariation.jl, group: Automa}
+          - {user: BioJulia, repo: GFF3.jl, group: Automa}
+          - {user: BioJulia, repo: XAM.jl, group: Automa}
+          - {user: dellison, repo: ConstituencyTrees.jl, group: Automa}
+          - {user: Kolaru, repo: MathTeXEngine.jl, group: Automa}
+          - {user: rasmushenningsson, repo: VariantCallFormat.jl, group: Automa}
+          - {user: TotalVerb, repo: SExpressions.jl, group: Automa}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine.
+            # It means we marked this as a breaking change, so we don't need to worry about.
+            # Mistakenly introducing a breaking change, as we have intentionally made one.
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end


### PR DESCRIPTION
This PR adds a GitHub workflow to test active direct dependents of Automa. The workflow is modelled on https://github.com/FluxML/Zygote.jl/blob/master/.github/workflows/Downstream.yml.
The value for the group parameter in the package matrix is set as `Automa`. See https://github.com/FluxML/Flux.jl/pull/1555#discussion_r687992977 for an example of the group parameter in use. Setting the parameter as `Automa` will give direct dependents a free opportunity to provide a reduced test set without the need to come back and change anything here. 

Example output: https://github.com/CiaranOMara/Automa.jl/actions/runs/1353068684
