### PR TITLE
Have Tokenizer check if in accept state when EOF

### DIFF
--- a/test/test09.jl
+++ b/test/test09.jl
@@ -9,6 +9,7 @@ using Test
     tokenizer = Automa.compile(
         re"a"      => :(emit(:a, ts:te)),
         re"a*b"    => :(emit(:ab, ts:te)),
+        re"cd"    => :(emit(:cd, ts:te)),
     )
     ctx = Automa.CodeGenContext()
 


### PR DESCRIPTION
In the code generated by generate_table_code for Tokenizer, if the loop exits
due to reaching EOF and current state is not an accept state, the current state
is set to a fail state (i.e. cs = -cs).

In other words, if the tokenizer reaches EOF while in the middle of a token,
it should fail.

Resolves issue #88