### PR TITLE
Fixup parse_class

### DIFF
--- a/src/re.jl
+++ b/src/re.jl
@@ -216,12 +216,14 @@ function prec(op::Symbol)
     end
 end
 
-# Convert this to ASCII byte
+# Convert this to ASCII byte.
+# Also accepts e.g. '\xff', but not a multi-byte Char
 function as_byte(c::Char)
-    if c > '\x7f'
-        error("Char '$c' cannot be expressed as an ASCII byte")
+    u = reinterpret(UInt32, c)
+    if u & 0x00ffffff != 0
+        error("Char '$c' cannot be expressed as a single byte")
     else
-        UInt8(c)
+        UInt8(u >> 24)
     end
 end
 

--- a/src/re.jl
+++ b/src/re.jl
@@ -216,25 +216,46 @@ function prec(op::Symbol)
     end
 end
 
+# Convert this to ASCII byte
+function as_byte(c::Char)
+    if c > '\x7f'
+        error("Char '$c' cannot be expressed as an ASCII byte")
+    else
+        UInt8(c)
+    end
+end
+
+# This parses things in square brackets, like [A-Za-z]
+# When this function is entered, the initial '[' has already been
+# consumed.
 function parse_class(str, s)
+    # The bool here is whether it's escaped
     chars = Tuple{Bool, Char}[]
     cs = iterate(str, s)
+    # Main loop: Get all the characters into the `chars` variable
     while cs !== nothing
         c, s = cs
         if c == ']'
+            # We are done with the class. Skip the ] char and break out.
             cs = iterate(str, s)
             break
+        # Handle escape character
         elseif c == '\\'
+            # If \ is the final char, throw error
             if iterate(str, s) === nothing
                 error("missing ]")
             end
+            # Else get the next char as escaped
             c, s = unescape(str, s)
             push!(chars, (true, c))
         else
+            # Ordinary char: Just add it unescaped
             push!(chars, (false, c))
         end
         cs = iterate(str, s)
     end
+    # If the first char is non-escaped ^, set head as cclass, meaning
+    # inverted class, and remove the first char.
     if !isempty(chars) && !first(chars)[1] && first(chars)[2] == '^'
         head = :cclass
         popfirst!(chars)
@@ -248,12 +269,14 @@ function parse_class(str, s)
     args = []
     while !isempty(chars)
         c = popfirst!(chars)[2]
-        if !isempty(chars) && !first(chars)[1] && first(chars)[2] == '-' && length(chars) ≥ 2
-            push!(args, UInt8(c):UInt8(chars[2][2]))
+        # If the next two chars are "-X" for any X, then this is a range.
+        # Create the right range and pop out the "-X"
+        if length(chars) ≥ 2 && first(chars) == (false, '-')
+            push!(args, as_byte(c):as_byte(chars[2][2]))
             popfirst!(chars)
             popfirst!(chars)
         else
-            push!(args, UInt8(c):UInt8(c))
+            push!(args, as_byte(c):as_byte(c))
         end
     end
     return RE(head, args), cs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,7 @@ include("test16.jl")
 include("test17.jl")
 include("test18.jl")
 include("simd.jl")
+include("unicode.jl")
 
 module TestFASTA
 using Test

--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -6,6 +6,8 @@ const re = Automa.RegExp
 using Test
 
 @testset "Unicode" begin
+    passes(machine::Automa.Machine, text) = iszero(first(Automa.execute(machine, text)))
+
     # No non-ASCII in character sets
     # This is not on principle, we just havne't implemented it yet,
     # and want to make sure we don't produce wrong results.
@@ -13,10 +15,17 @@ using Test
 
     # Unicode chars work like concatenated
     machine = Automa.compile(re"øæ")
-    @test Automa.execute(machine, "æ")[1] < 0
-    @test Automa.execute(machine, "ø")[1] < 0
-    @test Automa.execute(machine, "øæ")[1] == 0
-    @test Automa.execute(machine, collect(codeunits("øæ")))[1] == 0
+    @test !passes(machine, "æ")
+    @test !passes(machine, "ø")
+    @test passes(machine, "øæ")
+    @test passes(machine, collect(codeunits("øæ")))
+
+    # Byte ranges
+    machine = Automa.compile(re"[\x1a-\x29\xaa-\xf0]+")
+    @test passes(machine, "\xd0\xe9")
+    @test !passes(machine, "")
+    @test passes(machine, "\x20\xaa\xf0")
+    @test !passes(machine, "\x20\xaa\xf1")
 end
 
 end # module

--- a/test/unicode.jl
+++ b/test/unicode.jl
@@ -1,0 +1,22 @@
+module Unicode
+
+import Automa
+import Automa.RegExp: @re_str
+const re = Automa.RegExp
+using Test
+
+@testset "Unicode" begin
+    # No non-ASCII in character sets
+    # This is not on principle, we just havne't implemented it yet,
+    # and want to make sure we don't produce wrong results.
+    @test_throws Exception re.parse("[ø]")
+
+    # Unicode chars work like concatenated
+    machine = Automa.compile(re"øæ")
+    @test Automa.execute(machine, "æ")[1] < 0
+    @test Automa.execute(machine, "ø")[1] < 0
+    @test Automa.execute(machine, "øæ")[1] == 0
+    @test Automa.execute(machine, collect(codeunits("øæ")))[1] == 0
+end
+
+end # module


### PR DESCRIPTION
This code makes the following non-breaking changes:
* Add comments to part of the regex parsing code
* Make byte ranges in classes work, i.e. `re"[\xf1-\xff]"`, which incorrectly errored before
* Fix a bug on master, where a latin1 non-ascii char in a byte range, like `re"[ø]"` would be parsed incorrectly

FIxes #83 