### PR TITLE
Enforce action dict symbols are same as machines

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -117,17 +117,33 @@ Generate machine execution code with actions.
 """
 function generate_exec_code(ctx::CodeGenContext, machine::Machine, actions=nothing)
     # make actions
-    if actions === nothing
-        actions = Dict{Symbol,Expr}(a => quote nothing end for a in action_names(machine))
+    actions_dict::Dict{Symbol, Expr} = if actions === nothing
+        Dict{Symbol,Expr}(a => quote nothing end for a in machine_names(machine))
     elseif actions == :debug
-        actions = debug_actions(machine)
+        debug_actions(machine)
     elseif isa(actions, AbstractDict{Symbol,Expr})
-        actions = Dict{Symbol,Expr}(collect(actions))
+        d = Dict{Symbol,Expr}(collect(actions))
+
+        # check the set of actions is same as that of machine's
+        machine_acts = machine_names(machine)
+        dict_actions = Set(k for (k,v) in d)
+        for act in machine_acts
+            if act ∈ dict_actions
+                delete!(dict_actions, act)
+            else
+                error("Action \"$act\" of machine not present in input action Dict")
+            end
+        end
+        if length(dict_actions) > 0
+            error("Action \"$(first(dict_actions))\" not present in machine")
+        end
+        d
     else
         throw(ArgumentError("invalid actions argument"))
     end
+
     # generate code
-    code = ctx.generator(ctx, machine, actions)
+    code = ctx.generator(ctx, machine, actions_dict)
     if ctx.clean
         code = cleanup(code)
     end
@@ -653,25 +669,11 @@ function cleanup(ex::Expr)
     return Expr(ex.head, args...)
 end
 
-function action_names(machine::Machine)
-    actions = Set{Symbol}()
-    for s in traverse(machine.start)
-        for (e, t) in s.edges
-            union!(actions, a.name for a in e.actions)
-        end
-    end
-    for as in values(machine.eof_actions)
-        union!(actions, a.name for a in as)
-    end
-    return actions
-end
-
 function debug_actions(machine::Machine)
-    actions = action_names(machine)
     function log_expr(name)
         return :(push!(logger, $(QuoteNode(name))))
     end
-    return Dict{Symbol,Expr}(name => log_expr(name) for name in actions)
+    return Dict{Symbol,Expr}(name => log_expr(name) for name in machine_names(machine))
 end
 
 "If possible, remove self-simd edge."

--- a/src/machine.jl
+++ b/src/machine.jl
@@ -31,6 +31,27 @@ struct Machine
     eof_actions::Dict{Int,ActionList}
 end
 
+function action_names(machine::Machine)
+    actions = Set{Symbol}()
+    for s in traverse(machine.start)
+        for (e, t) in s.edges
+            union!(actions, a.name for a in e.actions)
+        end
+    end
+    for as in values(machine.eof_actions)
+        union!(actions, a.name for a in as)
+    end
+    return actions
+end
+
+function machine_names(machine::Machine)
+    actions = action_names(machine)
+    for node in traverse(machine.start), (e, _) in node.edges
+        union!(actions, e.precond.names)
+    end
+    return actions
+end
+
 function Base.show(io::IO, machine::Machine)
     print(io, summary(machine), "(<states=", machine.states, ",start_state=", machine.start_state, ",final_states=", machine.final_states, ">)")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,38 @@ Automa.Stream.generate_reader(:stripwhitespace, machine, actions=actions, initco
     end
 end
 
+@testset "Incorrect action names" begin
+    machine = let
+        a = re"abc"
+        a.actions[:enter] = [:foo, :bar]
+        b = re"bcd"
+        b.actions[:all] = [:qux]
+        b.when = :froom
+        c = re"x*"
+        c.actions[:exit] = []
+        Automa.compile(Automa.RegExp.cat(c, a | b))
+    end
+    ctx = Automa.CodeGenContext(generator=:goto)
+    actions = Dict(
+        :foo => quote nothing end,
+        :bar => quote nothing end,
+        :qux => quote nothing end,
+        :froom => quote 1 == 1.0 end
+    )
+
+    # Just test whether it throws or not
+    @test Automa.generate_exec_code(ctx, machine, nothing) isa Any
+    @test Automa.generate_exec_code(ctx, machine, :debug) isa Any
+    @test Automa.generate_exec_code(ctx, machine, actions) isa Any
+    @test_throws Exception Automa.generate_exec_code(ctx, machine, Dict{Symbol, Expr}())
+    delete!(actions, :froom)
+    @test_throws Exception Automa.generate_exec_code(ctx, machine, actions)
+    actions[:froom] = quote nothing end
+    actions[:missing_symbol] = quote nothing end
+    @test_throws Exception Automa.generate_exec_code(ctx, machine, actions)
+    @test Automa.generate_exec_code(ctx, machine, :debug) isa Any
+end
+
 # Three-column BED file format.
 cat = Automa.RegExp.cat
 rep = Automa.RegExp.rep


### PR DESCRIPTION
Before this PR, a user could forget or mis-spell a symbol in the action Dict
passed to generate_exec_code. Now add a check to throw an error if this happens.