### PR TITLE
Better error on compiling null regex

### DIFF
--- a/src/nfa.jl
+++ b/src/nfa.jl
@@ -168,6 +168,18 @@ function remove_dead_nodes(nfa::NFA)
         push!(get!(() -> Set{NFANode}(), backrefs, t), s)
     end
 
+    # Automa could support null regex like `re"A" & re"B"`, but it's trouble,
+    # and it's useless for the user, who would probably prefer an error.
+    # We throw this error here and not on NFA construction so the user can visualise
+    # the NFA and find the error in their regex
+    if !haskey(backrefs, nfa.final)
+        error(
+            "NFA matches the empty set Ø, and therefore consists of only dead nodes. " *
+            "Automa currently does not support converting null NFAs to DFAs. " *
+            "Double check your regex, or inspect the NFA."
+        )
+    end
+
     alive = Set{NFANode}()
     unvisited = [nfa.final]
     while !isempty(unvisited)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,18 @@ end
     @test occursin(r"^Automa\.Node\(.*\)$", repr(machine.start))
 end
 
+@testset "Null Regex" begin
+    re = Automa.RegExp
+    for null_regex in [
+        re"A" & re"B",
+        (re"B" | re"C") \ re"[A-D]",
+        !re.rep(re.any()),
+        !re"[\x00-\xff]*",
+    ]
+        @test_throws ErrorException Automa.compile(null_regex)
+    end
+end
+
 @testset "Determinacy" begin
     # see https://github.com/BioJulia/Automa.jl/issues/19
     notmach(re) = Automa.machine2dot(Automa.compile(re)) != Automa.machine2dot(Automa.compile(re))


### PR DESCRIPTION
It is possible for users to construct a regex that matches the null set, i.e.
no strings, not even the empty string. An example is `re"A" & re"B"`.
Automa could support these, but don't currently, as there is no point to.
However, attempting to compile such a regex currently throws an obscure internal
error.

This PR improves that error.

See issue #104