### PR TITLE
Backport from v1: Remove SIMD capability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,12 @@
 name = "Automa"
 uuid = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Jakob Nybo Nissen <jakobnybonissen@gmail.com"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
-ScanByte = "7b38b023-a4d7-4c5e-8d43-3f3097f304eb"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-ScanByte = "0.3.3"
 TranscodingStreams = "0.9"
 julia = "1.5"
 

--- a/src/Automa.jl
+++ b/src/Automa.jl
@@ -1,28 +1,6 @@
 module Automa
 
-import ScanByte: ScanByte, ByteSet
-
-# Encode a byte set into a sequence of non-empty ranges.
-function range_encode(set::ScanByte.ByteSet)
-    result = UnitRange{UInt8}[]
-    it = iterate(set)
-    it === nothing && return result
-    start, state = it
-    lastbyte = byte = start
-    it = iterate(set)
-    while it !== nothing
-        byte, state = it
-        if byte > lastbyte + 1
-            push!(result, start:lastbyte)
-            start = byte
-        end
-        lastbyte = byte
-        it = iterate(set, state)
-    end
-    push!(result, start:byte)
-    return result
-end
-
+include("byteset.jl")
 include("re.jl")
 include("precond.jl")
 include("action.jl")

--- a/src/byteset.jl
+++ b/src/byteset.jl
@@ -1,0 +1,93 @@
+struct ByteSet <: AbstractSet{UInt8}
+    data::NTuple{4, UInt64}
+    ByteSet(x::NTuple{4, UInt64}) = new(x)
+end
+
+ByteSet() = ByteSet((UInt64(0), UInt64(0), UInt64(0), UInt64(0)))
+Base.length(s::ByteSet) = mapreduce(count_ones, +, s.data)
+Base.isempty(s::ByteSet) = s === ByteSet()
+
+function ByteSet(it)
+    a = b = c = d = UInt64(0)
+    for i in it
+        vi = convert(UInt8, i)
+        if vi < 0x40
+            a |= UInt(1) << ((vi - 0x00) & 0x3f)
+        elseif vi < 0x80
+            b |= UInt(1) << ((vi - 0x40) & 0x3f)
+        elseif vi < 0xc0
+            c |= UInt(1) << ((vi - 0x80) & 0x3f)
+        else
+            d |= UInt(1) << ((vi - 0xc0) & 0x3f)
+        end
+    end
+    ByteSet((a, b, c, d))
+end
+
+function Base.minimum(s::ByteSet)
+    y = iterate(s)
+    y === nothing ? Base._empty_reduce_error() : first(y)
+end
+
+function Base.maximum(s::ByteSet)
+    offset = 0x03 * UInt8(64)
+    for i in 0:3
+        @inbounds bits = s.data[4 - i]
+        iszero(bits) && continue
+        return ((3-i)*64 + (64 - leading_zeros(bits)) - 1) % UInt8
+    end
+    Base._empty_reduce_error()
+end
+
+function Base.in(byte::UInt8, s::ByteSet)
+    i, o = divrem(byte, UInt8(64))
+    @inbounds !(iszero(s.data[i & 0x03 + 0x01] >>> (o & 0x3f) & UInt(1)))
+end
+
+@inline function Base.iterate(s::ByteSet, state=UInt(0))
+    ioffset, offset = divrem(state, UInt(64))
+    n = UInt(0)
+    while iszero(n)
+        ioffset > 3 && return nothing
+        n = s.data[ioffset + 1] >>> offset
+        offset *= !iszero(n)
+        ioffset += 1
+    end
+    tz = trailing_zeros(n)
+    result = (64 * (ioffset - 1) + offset + tz) % UInt8
+    (result, UInt(result) + UInt(1))
+end
+
+function Base.:~(s::ByteSet)
+    a, b, c, d = s.data
+    ByteSet((~a, ~b, ~c, ~d))
+end
+
+is_contiguous(s::ByteSet) = isempty(s) || (maximum(s) - minimum(s) + 1 == length(s))
+
+Base.union(a::ByteSet, b::ByteSet) = ByteSet(map(|, a.data, b.data))
+Base.intersect(a::ByteSet, b::ByteSet) = ByteSet(map(&, a.data, b.data))
+Base.symdiff(a::ByteSet, b::ByteSet) = ByteSet(map(⊻, a.data, b.data))
+Base.setdiff(a::ByteSet, b::ByteSet) = ByteSet(map((i,j) -> i & ~j, a.data, b.data))
+Base.isdisjoint(a::ByteSet, b::ByteSet) = isempty(intersect(a, b))
+
+# Encode a byte set into a sequence of non-empty ranges.
+function range_encode(set::ByteSet)
+    result = UnitRange{UInt8}[]
+    it = iterate(set)
+    it === nothing && return result
+    start, state = it
+    lastbyte = byte = start
+    it = iterate(set)
+    while it !== nothing
+        byte, state = it
+        if byte > lastbyte + 1
+            push!(result, start:lastbyte)
+            start = byte
+        end
+        lastbyte = byte
+        it = iterate(set, state)
+    end
+    push!(result, start:byte)
+    return result
+end

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -71,15 +71,9 @@ function CodeGenContext(;
     elseif loopunroll > 0 && generator != :goto
         throw(ArgumentError("loop unrolling is not supported for $(generator)"))
     end
-    # special conditions for simd generator
+    # SIMD generator disabled
     if generator == :simd
-        if loopunroll != 0
-            throw(ArgumentError("SIMD generator does not support unrolling"))
-        elseif getbyte != Base.getindex
-            throw(ArgumentError("SIMD generator only support Base.getindex"))
-        elseif checkbounds
-            throw(ArgumentError("SIMD generator does not support boundscheck"))
-        end
+        generator = :goto
     end
     # check generator
     if generator == :table
@@ -88,8 +82,6 @@ function CodeGenContext(;
         generator = generate_inline_code
     elseif generator == :goto
         generator = generate_goto_code
-    elseif generator == :simd
-        generator = generate_simd_code
     else
         throw(ArgumentError("invalid code generator: $(generator)"))
     end
@@ -324,102 +316,6 @@ function generate_goto_code(ctx::CodeGenContext, machine::Machine, actions::Dict
     end
 end
 
-function generate_simd_code(ctx::CodeGenContext, machine::Machine, actions::Dict{Symbol,Expr})
-    ## SAME AS GOTO BEGIN
-    actions_in = Dict{Node,Set{Vector{Symbol}}}()
-    for s in traverse(machine.start), (e, t) in s.edges
-        push!(get!(actions_in, t, Set{Vector{Symbol}}()), action_names(e.actions))
-    end
-    action_label = Dict{Node,Dict{Vector{Symbol},Symbol}}()
-    for s in traverse(machine.start)
-        action_label[s] = Dict()
-        if haskey(actions_in, s)
-            for (i, names) in enumerate(actions_in[s])
-                action_label[s][names] = Symbol("state_", s.state, "_action_", i)
-            end
-        end
-    end
-
-    blocks = Expr[]
-    for s in traverse(machine.start)
-        block = Expr(:block)
-        for (names, label) in action_label[s]
-            if isempty(names)
-                continue
-            end
-            append_code!(block, quote
-                @label $(label)
-                $(rewrite_special_macros(ctx, generate_action_code(names, actions), false, s.state))
-                @goto $(Symbol("state_", s.state))
-            end)
-        end
-
-        append_code!(block, quote
-            @label $(Symbol("state_", s.state))
-            $(ctx.vars.p) += 1
-            if $(ctx.vars.p) > $(ctx.vars.p_end)
-                $(ctx.vars.cs) = $(s.state)
-                @goto exit
-            end
-        end)
-
-        ### END SAME
-        simd, non_simd = peel_simd_edge(s)
-        simd_code = if simd !== nothing
-            quote
-                $(generate_simd_loop(ctx, simd.labels))
-                if $(ctx.vars.p) > $(ctx.vars.p_end)
-                    $(ctx.vars.cs) = $(s.state)
-                    @goto exit
-                end
-            end
-        else
-            :()
-        end
-            
-        default = :($(ctx.vars.cs) = $(-s.state); @goto exit)
-        dispatch_code = foldr(default, optimize_edge_order(non_simd)) do edge, els
-            e, t = edge
-            if isempty(e.actions)
-                then = :(@goto $(Symbol("state_", t.state)))
-            else
-                then = :(@goto $(action_label[t][action_names(e.actions)]))
-            end
-            return Expr(:if, generate_condition_code(ctx, e, actions), then, els)
-        end
-        # BEGIN SAME AGAIN
-        append_code!(block, quote
-            @label $(Symbol("state_case_", s.state))
-            $(simd_code)
-            $(generate_getbyte_code(ctx))
-            $(dispatch_code)
-        end)
-        push!(blocks, block)
-    end
-
-    enter_code = foldr(:(@goto exit), machine.states) do s, els
-        return Expr(:if, :($(ctx.vars.cs) == $(s)), :(@goto $(Symbol("state_case_", s))), els)
-    end
-
-    eof_action_code = rewrite_special_macros(ctx, generate_eof_action_code(ctx, machine, actions), true)
-    final_state_code = generate_final_state_mem_code(ctx, machine)
-
-    return quote
-        if $(ctx.vars.p) > $(ctx.vars.p_end)
-            @goto exit
-        end
-        $(ctx.vars.mem) = $(SizedMemory)($(ctx.vars.data))
-        $(enter_code)
-        $(Expr(:block, blocks...))
-        @label exit
-        if $(ctx.vars.p) > $(ctx.vars.p_eof) ≥ 0 && $(final_state_code)
-            $(eof_action_code)
-            $(ctx.vars.cs) = 0
-        end
-    end
-end
-
-
 function append_code!(block::Expr, code::Expr)
     @assert block.head == :block
     @assert code.head == :block
@@ -458,29 +354,6 @@ function generate_unrolled_loop(ctx::CodeGenContext, edge::Edge, t::Node)
         end
         @goto $(Symbol("state_", t.state))
     end
-end
-
-# Note: This function has been carefully crafted to produce (nearly) optimal
-# assembly code for AVX2-capable CPUs. Change with great care.
-function generate_simd_loop(ctx::CodeGenContext, bs::ByteSet)
-    byteset = ~ScanByte.ByteSet(bs)
-    bsym = gensym()
-    quote
-        $bsym = Automa.loop_simd(
-            $(ctx.vars.mem).ptr + $(ctx.vars.p) - 1,
-            ($(ctx.vars.p_end) - $(ctx.vars.p) + 1) % UInt,
-            Val($byteset)
-        )
-        $(ctx.vars.p) = if $bsym === nothing
-            $(ctx.vars.p_end) + 1
-        else
-            $(ctx.vars.p) + $bsym - 1
-        end
-    end
-end
-
-@inline function loop_simd(ptr::Ptr, len::UInt, valbs::Val)
-    ScanByte.memchr(ptr, len, valbs)
 end
 
 function generate_eof_action_code(ctx::CodeGenContext, machine::Machine, actions::Dict{Symbol,Expr})
@@ -672,22 +545,7 @@ function debug_actions(machine::Machine)
         return :(push!(logger, $(QuoteNode(name))))
     end
     return Dict{Symbol,Expr}(name => log_expr(name) for name in actions)
-end
-
-"If possible, remove self-simd edge."
-function peel_simd_edge(node)
-    non_simd = Tuple{Edge, Node}[]
-    simd = nothing
-    for (e, t) in node.edges
-        if t === node && isempty(e.actions) && isempty(e.precond)
-            simd = e
-        else
-            push!(non_simd, (e, t))
-        end
-    end
-    return simd, non_simd
-end
-    
+end 
 
 # Sort edges by its size in descending order.
 function optimize_edge_order(edges)

--- a/test/simd.jl
+++ b/test/simd.jl
@@ -1,9 +1,6 @@
 # Test codegencontext
 @testset "CodeGenContext" begin
     @test_throws ArgumentError Automa.CodeGenContext(generator=:fdjfhkdj)
-    @test_throws ArgumentError Automa.CodeGenContext(generator=:simd)
-    @test_throws ArgumentError Automa.CodeGenContext(generator=:simd, checkbounds=false, loopunroll=2)
-    @test_throws ArgumentError Automa.CodeGenContext(generator=:simd, checkbounds=false, getbyte=identity)
 end
 
 import Automa


### PR DESCRIPTION
I've come to the conclusion that Julia does not make it possible to robustly check what CPU instructions the user has available. The current options are all undocumented, complex and brittle, and not suitable for code that cannot be accepted to break at any time

Whenever a robust way of checking for CPU instructions are available, the change is easy to revert.