### PR TITLE
Tokenizer improvements

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,6 +127,7 @@ include("input_error.jl")
 include("simd.jl")
 include("unicode.jl")
 include("validator.jl")
+include("tokenizer.jl")
 
 module TestFASTA
 using Test

--- a/test/tokenizer.jl
+++ b/test/tokenizer.jl
@@ -5,31 +5,43 @@ using Automa
 using Test
 
 @testset "Tokenizer" begin
-    for goto in (false, true)
-        make_tokenizer(:token_iter, compile([
-            re"ADF",
-            re"[A-Z]+",
-            re"[abcde]+",
-            re"abc",
-            re"ab[a-z]"
-        ]); goto=goto) |> eval
-        tokenize(x) = collect(token_iter(x))
+    # TODO: This could be a loop over (false, true),
+    # but Julia #51267 prevents this for now
+    make_tokenizer([
+        re"ADF",
+        re"[A-Z]+",
+        re"[abcde]+",
+        re"abc",
+        re"ab[a-z]"
+    ]; goto=false, version=1) |> eval
 
+    make_tokenizer([
+        re"ADF",
+        re"[A-Z]+",
+        re"[abcde]+",
+        re"abc",
+        re"ab[a-z]"
+    ]; goto=true, version=2) |> eval
+
+    for f in (
+        (i -> collect(tokenize(UInt32, i, 1))),
+        (i -> collect(tokenize(UInt32, i, 2)))
+    )
         # Empty
-        @test tokenize("") == []
+        @test f("") == []
 
         # Only error
-        @test tokenize("!"^11) == [(1, 11, 0)]
+        @test f("!"^11) == [(1, 11, 0)]
 
         # Longest token wins
-        @test tokenize("abca") == [(1, 4, 3)]
-        @test tokenize("ADFADF") == [(1, 6, 2)]
-        @test tokenize("AD") == [(1, 2, 2)]
+        @test f("abca") == [(1, 4, 3)]
+        @test f("ADFADF") == [(1, 6, 2)]
+        @test f("AD") == [(1, 2, 2)]
 
         # Ties are broken with last token
-        @test tokenize("ADF") == [(1, 3, 2)]
-        @test tokenize("abc") == [(1, 3, 5)]
-        @test tokenize("abe") == [(1, 3, 5)]
+        @test f("ADF") == [(1, 3, 2)]
+        @test f("abc") == [(1, 3, 5)]
+        @test f("abe") == [(1, 3, 5)]
     end
 end
 


### PR DESCRIPTION
Bugfixes and doc improvements to Tokenizer

Issue 125 revealed several issues with the existing tokenizer implementation,
several of which are fixed here:

* `tokenize` now correctly uses the `version` argument
* Documentation is now clearer, and several tokenizer functions are doctested
* Several tokenizer tests were forgotten - these are now included and updated
  to work.