### PR TITLE
Bump TranscodingStreams to 0.11

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -15,13 +15,20 @@ jobs:
           - '1.6' # LTS
           - '1'
         julia-arch: [x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         experimental: [false]
         include:
           - julia-version: nightly
             julia-arch: x86
             os: ubuntu-latest
             experimental: true
+          # MacOS Aarch64 reached Tier1 support of Julia in version 1.9
+          - julia-version: '1.9'
+            os: macOS-latest
+            experimental: false
+          - julia-version: '1'
+            os: macOS-latest
+            experimental: false
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Setup Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
       - name: Run Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.4]
+* Bump TranscodingStreams to version 0.11
+
 ## [1.0.3]
 * Fix a bug when displaying Automa machine errors when the user has not imported
   the symbol Automa

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Automa"
 uuid = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
 authors = ["Kenta Sato <bicycle1885@gmail.com>", "Jakob Nybo Nissen <jakobnybonissen@gmail.com"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -10,7 +10,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 julia = "1.6"
 PrecompileTools = "1"
-TranscodingStreams = "0.9, 0.10"
+TranscodingStreams = "0.9, 0.10, 0.11"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
TranscodingStreams release notes: https://github.com/JuliaIO/TranscodingStreams.jl/releases/tag/v0.11.0

The `seekend` and `Memory` changes do not affect this package.

The changes to `eof` may mean that `Automa.jl` may error differently when accidentally trying to read a closed stream, but I don't think this changes the API of `Automa.jl`.