### PR TITLE
Re-enable SIMD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "1.0.4"
 
 [deps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-julia = "1.6"
 PrecompileTools = "1"
+SIMD = "3.6.0"
 TranscodingStreams = "0.9, 0.10, 0.11"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Automa.jl
+++ b/src/Automa.jl
@@ -1,6 +1,7 @@
 module Automa
 
 using TranscodingStreams: TranscodingStreams, TranscodingStream, NoopStream
+using SIMD: SIMD, Vec, vload
 
 include("byteset.jl")
 


### PR DESCRIPTION
Use a simpler SIMD algorithm than the one from ScanByte. This will give worse performance, but still better than not using SIMD. Initial benchmarks suggests a 2x performance increase in the best case.