### PR TITLE
remove SIMD dep to get less method invalidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Remove the SIMD.jl dependency without loss of performance
+
 ## [1.2.0]
 * Add `Base.copy(::RE)` to more easily generate multiple regex with different
   actions

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,10 @@ version = "1.2.0"
 
 [deps]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 PrecompileTools = "1"
-SIMD = "3.6.0"
 TranscodingStreams = "0.9, 0.10, 0.11"
 julia = "1.6"
 

--- a/src/Automa.jl
+++ b/src/Automa.jl
@@ -1,7 +1,6 @@
 module Automa
 
 using TranscodingStreams: TranscodingStreams, TranscodingStream, NoopStream
-using SIMD: SIMD, Vec, vload
 
 include("byteset.jl")
 

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -552,27 +552,32 @@ function append_code!(block::Expr, code::Expr)
 end
 
 function generate_simd_loop(ctx::CodeGenContext, bs::ByteSet, state::Int)
-    vsym = gensym()
-    rsym = gensym()
-    block = Expr(:block)
-    for range in range_encode(bs)
-        expr = if length(range) == 1
-            quote
-                $(rsym) |= ($(vsym) == $(first(range)))
-            end
+    bsym = gensym()
+    accsym = gensym()
+    isym = gensym()
+    # Branch-free membership test (| and & instead of short-circuiting
+    # || / `in`): together with the fixed 32-iteration loop below this is a
+    # pure Bool reduction, which LLVM's loop vectorizer compiles to the same
+    # vpcmp/vpand vector code the previous, explicitly SIMD.jl-based
+    # implementation emitted - without the SIMD.jl dependency (whose broad
+    # Base-operator methods invalidate compiled code across the ecosystem in
+    # every session loading Automa).
+    membership = foldr(:(false), range_encode(bs)) do range, cond
+        test = if length(range) == 1
+            :($(bsym) == $(first(range)))
         else
-            quote
-                $(rsym) |= ($(vsym) >= $(first(range))) & ($(vsym) <= $(last(range)))
-            end
+            :(($(bsym) >= $(first(range))) & ($(bsym) <= $(last(range))))
         end
-        append_code!(block, expr)
+        Expr(:call, :|, test, cond)
     end
     quote
         while $(ctx.vars.p) + 30 < $(ctx.vars.p_end)
-            $(vsym) = @inbounds $(SIMD.vload)($(Vec{32, UInt8}), $(ctx.vars.mem).ptr + $(ctx.vars.p) - 1, nothing, Val(false), Val(false))
-            $(rsym) = $(Vec{32, Bool})(false)
-            $(block)
-            all($(rsym)) || break
+            $(accsym) = true
+            for $(isym) in 0:31
+                $(bsym) = @inbounds getindex($(ctx.vars.mem), $(ctx.vars.p) + $(isym))
+                $(accsym) &= $(membership)
+            end
+            $(accsym) || break
             $(ctx.vars.p) += 32
         end
         while true


### PR DESCRIPTION
# Remove the SIMD.jl dependency

While looking into Makie method invalidations, SIMD was a big invalidator
(its broad Base operator methods like `>(::Union{Bool, Int8, ...}, ::Vec)`
invalidate a lot of compiled code in unrelated packages, we traced
multi-second recompilations of an HTTP server to it), and since we depend on
Automa indirectly via MathTeXEngine, it seemed easiest to just remove that
dependency here.

SIMD.jl was only used in `generate_simd_loop`. It now emits a branch-free,
fixed 32-iteration loop instead, which LLVM auto-vectorizes to the same
vector code. Judged with BenchmarkTools (validator over ~1MB inputs, medians):

|                             | SIMD.jl   | this PR   | `judge`             |
|-----------------------------|-----------|-----------|---------------------|
| long `[a-z]+` runs          | 13.14 μs  | 13.24 μs  | +0.8% (invariant)   |
| 4-range set `[A-Za-z0-9_]+` | 30.29 μs  | 24.11 μs  | -20.4% (improvement)|

Note: the skip loop now respects `--check-bounds=yes` (the raw `vload`
bypassed it), so benchmark with default flags.

<details>
<summary>Benchmark script</summary>

Run with `julia bench.jl out.json` on master and on this branch, then compare
with `judge`:

```julia
using Automa, BenchmarkTools

ctx = Automa.CodeGenContext(generator = :goto)
code_runs = Automa.generate_code(ctx, Automa.compile(re"([a-z]+,)+"), nothing)
@eval function validate_runs(data)
    $(code_runs)
    return cs == 0
end
code_ranges = Automa.generate_code(ctx, Automa.compile(re"([A-Za-z0-9_]+ )+"), nothing)
@eval function validate_ranges(data)
    $(code_ranges)
    return cs == 0
end

# long skippable runs (best case for the skip loop), and a byte set
# needing several compares per chunk
data_runs = (repeat("a", 10_000) * ",")^100
data_ranges = (repeat("aZ9_", 2500) * " ")^100
@assert validate_runs(data_runs) && validate_ranges(data_ranges)

suite = BenchmarkGroup()
suite["long_runs"] = @benchmarkable validate_runs($data_runs)
suite["multi_range"] = @benchmarkable validate_ranges($data_ranges)
tune!(suite)
BenchmarkTools.save(ARGS[1], run(suite; seconds = 20))
```

```julia
using BenchmarkTools
pr, base = only(BenchmarkTools.load("pr.json")), only(BenchmarkTools.load("master.json"))
judge(median(pr), median(base))
```

</details>
